### PR TITLE
chore(root): 🪲 fix VSCode formatting, use eslint instead

### DIFF
--- a/.github/instructions/read-only.instructions.md
+++ b/.github/instructions/read-only.instructions.md
@@ -1,0 +1,1 @@
+Don't make any changes to the code. Just read, analyze and explain!

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -175,7 +175,10 @@
   "commit-message-editor.view.defaultView": "form",
   "commit-message-editor.view.visibleViews": "form",
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": "explicit"
+    "source.fixAll.eslint": "explicit",
+    "source.fixAll": "never",
+    "source.fixAll.sortJSON": "never",
+    "source.organizeImports": "never"
   },
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   "editor.formatOnSave": true,

--- a/apps/frontend-e2e/playwright.config.ts
+++ b/apps/frontend-e2e/playwright.config.ts
@@ -1,6 +1,6 @@
-import { defineConfig, devices } from '@playwright/test';
-import { nxE2EPreset } from '@nx/playwright/preset';
 import { workspaceRoot } from '@nx/devkit';
+import { nxE2EPreset } from '@nx/playwright/preset';
+import { defineConfig, devices } from '@playwright/test';
 
 // For CI, you may want to set BASE_URL to the deployed application.
 const baseURL = process.env['BASE_URL'] || 'http://localhost:4200';

--- a/apps/frontend-e2e/src/example.spec.ts
+++ b/apps/frontend-e2e/src/example.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { expect, test } from '@playwright/test';
 
 test('has title', async ({ page }) => {
   await page.goto('/');

--- a/apps/frontend/src/app/app.component.spec.ts
+++ b/apps/frontend/src/app/app.component.spec.ts
@@ -1,7 +1,8 @@
 import { TestBed } from '@angular/core/testing';
+import { RouterModule } from '@angular/router';
+
 import { AppComponent } from './app.component';
 import { NxWelcomeComponent } from './nx-welcome.component';
-import { RouterModule } from '@angular/router';
 
 describe('AppComponent', () => {
   beforeEach(async () => {

--- a/apps/frontend/src/app/app.component.ts
+++ b/apps/frontend/src/app/app.component.ts
@@ -1,5 +1,6 @@
 import { Component } from '@angular/core';
 import { RouterModule } from '@angular/router';
+
 import { NxWelcomeComponent } from './nx-welcome.component';
 
 @Component({

--- a/apps/frontend/src/app/app.config.server.ts
+++ b/apps/frontend/src/app/app.config.server.ts
@@ -1,5 +1,6 @@
-import { mergeApplicationConfig, ApplicationConfig } from '@angular/core';
+import { ApplicationConfig, mergeApplicationConfig } from '@angular/core';
 import { provideServerRendering } from '@angular/platform-server';
+
 import { appConfig } from './app.config';
 
 const serverConfig: ApplicationConfig = {

--- a/apps/frontend/src/app/app.config.ts
+++ b/apps/frontend/src/app/app.config.ts
@@ -1,10 +1,11 @@
 import { ApplicationConfig, provideZoneChangeDetection } from '@angular/core';
-import { provideRouter } from '@angular/router';
-import { appRoutes } from './app.routes';
 import {
   provideClientHydration,
   withEventReplay,
 } from '@angular/platform-browser';
+import { provideRouter } from '@angular/router';
+
+import { appRoutes } from './app.routes';
 
 export const appConfig: ApplicationConfig = {
   providers: [

--- a/apps/frontend/src/app/nx-welcome.component.ts
+++ b/apps/frontend/src/app/nx-welcome.component.ts
@@ -1,5 +1,5 @@
-import { Component, ViewEncapsulation } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { Component, ViewEncapsulation } from '@angular/core';
 
 @Component({
   selector: 'app-nx-welcome',

--- a/apps/frontend/src/main.server.ts
+++ b/apps/frontend/src/main.server.ts
@@ -1,4 +1,5 @@
 import { bootstrapApplication } from '@angular/platform-browser';
+
 import { AppComponent } from './app/app.component';
 import { config } from './app/app.config.server';
 

--- a/apps/frontend/src/main.ts
+++ b/apps/frontend/src/main.ts
@@ -1,5 +1,6 @@
 import { bootstrapApplication } from '@angular/platform-browser';
-import { appConfig } from './app/app.config';
+
 import { AppComponent } from './app/app.component';
+import { appConfig } from './app/app.config';
 
 bootstrapApplication(AppComponent, appConfig).catch(err => console.error(err));

--- a/apps/frontend/src/server.ts
+++ b/apps/frontend/src/server.ts
@@ -1,10 +1,12 @@
 import 'zone.js/node';
 
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+
 import { APP_BASE_HREF } from '@angular/common';
 import { CommonEngine } from '@angular/ssr/node';
 import * as express from 'express';
-import { existsSync } from 'node:fs';
-import { join } from 'node:path';
+
 import bootstrap from './main.server';
 
 // The Express app is exported so that it can be used by serverless Functions.

--- a/apps/frontend/src/test-setup.ts
+++ b/apps/frontend/src/test-setup.ts
@@ -1,10 +1,10 @@
 import '@analogjs/vitest-angular/setup-zone';
 
+import { getTestBed } from '@angular/core/testing';
 import {
   BrowserDynamicTestingModule,
   platformBrowserDynamicTesting,
 } from '@angular/platform-browser-dynamic/testing';
-import { getTestBed } from '@angular/core/testing';
 
 getTestBed().initTestEnvironment(
   BrowserDynamicTestingModule,

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,5 +1,6 @@
 import nx from '@nx/eslint-plugin';
 import prettier from 'eslint-config-prettier';
+import simpleImportSort from 'eslint-plugin-simple-import-sort';
 
 export default [
   ...nx.configs['flat/base'],
@@ -15,7 +16,12 @@ export default [
   },
   {
     files: ['**/*.ts', '**/*.tsx', '**/*.js', '**/*.jsx'],
+    plugins: {
+      'simple-import-sort': simpleImportSort,
+    },
     rules: {
+      'simple-import-sort/imports': 'error',
+      'simple-import-sort/exports': 'error',
       '@nx/enforce-module-boundaries': [
         'error',
         {

--- a/package-lock.json
+++ b/package-lock.json
@@ -59,6 +59,7 @@
         "eslint": "^9.8.0",
         "eslint-config-prettier": "^10.0.0",
         "eslint-plugin-playwright": "^1.6.2",
+        "eslint-plugin-simple-import-sort": "^12.1.1",
         "husky": "^9.1.7",
         "jiti": "2.4.2",
         "jsdom": "~22.1.0",
@@ -13775,6 +13776,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint-plugin-simple-import-sort": {
+      "version": "12.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-simple-import-sort/-/eslint-plugin-simple-import-sort-12.1.1.tgz",
+      "integrity": "sha512-6nuzu4xwQtE3332Uz0to+TxDQYRLTKRESSc2hefVT48Zc8JthmN23Gx9lnYhu0FtkRSL1oxny3kJ2aveVhmOVA==",
+      "dev": true,
+      "peerDependencies": {
+        "eslint": ">=5.0.0"
       }
     },
     "node_modules/eslint-scope": {

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "eslint": "^9.8.0",
     "eslint-config-prettier": "^10.0.0",
     "eslint-plugin-playwright": "^1.6.2",
+    "eslint-plugin-simple-import-sort": "^12.1.1",
     "husky": "^9.1.7",
     "jiti": "2.4.2",
     "jsdom": "~22.1.0",


### PR DESCRIPTION
- VScode on save actions defined in user settings were applied regardless of eslint and prettier
- overriding the onSave actions on workspace level now
- add eslint rule to organize imports