### PR TITLE
ci(root): 🪲 setup nx cloud CI

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -8,6 +8,9 @@ on:
         required: false
         type: string
 
+env:
+  NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
+
 jobs:
   build-and-test:
     name: Build and Test


### PR DESCRIPTION
because the CI stopped working after using NX for 3 days