### PR TITLE
fix(frontend): 🪲 matching `GitHub Actions` search term

### DIFF
--- a/libs/data-access/taxonomy/src/lib/taxonomy.data.ts
+++ b/libs/data-access/taxonomy/src/lib/taxonomy.data.ts
@@ -818,6 +818,7 @@ const INTERNAL_TAXONOMY = [
     categories: ['DevOps & Build & CI/CD'],
     children: ['BitBucket', 'GitHub', 'GitLab'],
     related: ['CI/CD', 'Conventional Commits', 'SVN', 'TFS'],
+    synonyms: [/^git$/i],
   },
   {
     canonical: 'GitHub Actions',
@@ -844,6 +845,7 @@ const INTERNAL_TAXONOMY = [
     children: ['GitHub Actions', 'GitHub API'],
     parents: ['Git'],
     related: ['CI/CD'],
+    synonyms: [/^github$/i],
   },
   {
     canonical: 'GitLab CI',


### PR DESCRIPTION
before, it also fully matched `Git` and `GitHub`