### PR TITLE
fix(multiple): 📦 VSCode auto-sort imports inconsistencies

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -183,7 +183,7 @@
     "source.fixAll.eslint": "explicit",
     "source.fixAll": "never",
     "source.fixAll.sortJSON": "never",
-    "source.organizeImports": "explicit"
+    "source.organizeImports": "never"
   },
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   "editor.formatOnSave": true,


### PR DESCRIPTION
- disable VSCodes `source.organizeImports`, since it's redundant and contradictory with existing `"source.fixAll.eslint": "explicit"`