### PR TITLE
fix(frontend): 🪲 wrap footer layout on narrow desktops

### DIFF
--- a/libs/feature/footer/project.json
+++ b/libs/feature/footer/project.json
@@ -5,6 +5,7 @@
   "prefix": "lib",
   "projectType": "library",
   "tags": ["layer:feature", "type:top-level"],
+  "implicitDependencies": ["shared-styles"],
   "targets": {
     "test": {
       "executor": "@nx/jest:jest",

--- a/libs/feature/footer/src/lib/footer.component.scss
+++ b/libs/feature/footer/src/lib/footer.component.scss
@@ -1,3 +1,5 @@
+@use 'breakpoints' as breakpoints;
+
 .footer {
   width: 100%;
   margin-top: auto;
@@ -107,7 +109,17 @@
   opacity: 0.6;
 }
 
-@media (max-width: 768px) {
+@include breakpoints.desktop-up {
+  .footer-content {
+    flex-wrap: wrap;
+  }
+
+  .footer-brand-link {
+    flex-wrap: wrap;
+  }
+}
+
+@include breakpoints.mobile-only {
   .footer-content {
     flex-direction: column;
     align-items: center;


### PR DESCRIPTION
to avoid vertical scroll bar

Co-authored-by: Copilot <copilot@github.com>