### PR TITLE
fix(frontend): 🪲 restrict taxonomy term match of `vite` to exclude `vitest`

### DIFF
--- a/libs/data-access/taxonomy/src/lib/taxonomy.data.ts
+++ b/libs/data-access/taxonomy/src/lib/taxonomy.data.ts
@@ -2273,6 +2273,7 @@ const INTERNAL_TAXONOMY: Record<InternalTagName, TaxonomyData> = {
     categories: ['DevOps & Build & CI/CD', 'Tools & Libraries'],
     parents: ['Build Tools'],
     related: ['Webpack'],
+    synonyms: [/^vite$/i],
   },
   VSCode: {
     canonical: 'VSCode',


### PR DESCRIPTION
only full string matching