### PR TITLE
feat(frontend): ✨ update hero summary to reflect 25 years of experience in software development

### DIFF
--- a/apps/frontend-e2e/src/tests/about-me.spec.ts
+++ b/apps/frontend-e2e/src/tests/about-me.spec.ts
@@ -21,7 +21,7 @@ test.describe('About Me Section', () => {
     );
     await expect(aboutMe.heroLocation).toHaveText('Berlin (Germany)');
     await expect(aboutMe.heroSummary).toHaveText(
-      /Well-organized.*professional.*business/s
+      /\d\d years.*ownership.*solutions/s
     );
   });
 

--- a/libs/feature/about-me/src/lib/hero-content/hero-content.component.html
+++ b/libs/feature/about-me/src/lib/hero-content/hero-content.component.html
@@ -28,9 +28,9 @@
         }
       </div>
       <p class="hero-summary">
-        Well-organized, broad-minded, passionate and responsible IT
-        professional. Focus on aligning technical solutions with business
-        objectives.
+        25 years of experience in software development, well-organized, with a
+        broad technical perspective and a strong sense of ownership. Focused on
+        aligning technical solutions with business objectives.
       </p>
     </div>
   </div>


### PR DESCRIPTION
- remove `passionate`, as it's a generic unproved claim
- replace `broad-minded` with `broad technical perspective` for more clarity.
   - I'm not a hippy, but a generalist
- `responsible` with `ownership` for more clarity
   - I'm not simply a reliable code monkey